### PR TITLE
Exécution des fichiers .algo : transpileur Python + bouton ▶ Exécuter

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Une extension qui fournit la coloration syntaxique et des extraits de code (snip
 ![algorithme-tn](https://github.com/romoez/algo-tn-vscode/raw/main/images/algorithme-tn.gif)
 
 -   [Algorithme en Pseudocode](#algorithme-en-pseudocode)
+    -   [Exécution des algorithmes](#exécution-des-algorithmes)
     -   [Coloration Syntaxique](#coloration-syntaxique)
         -   [Commentaires](#commentaires)
         -   [Mots clés](#mots-clés)
@@ -30,6 +31,18 @@ Une extension qui fournit la coloration syntaxique et des extraits de code (snip
         -   [0.0.3](#003)
         -   [0.0.2](#002)
         -   [0.0.1](#001)
+
+## Exécution des algorithmes
+
+Le dossier [`tools/`](tools/) contient `algotn.py`, un transpileur qui traduit
+les fichiers `.algo` en Python puis les exécute dans le terminal (Python 3.10+,
+aucune dépendance) :
+
+```console
+python tools/algotn.py mon_algo.algo
+```
+
+Voir [tools/README.md](tools/README.md) pour la liste des structures supportées.
 
 ## Coloration Syntaxique
 

--- a/README.md
+++ b/README.md
@@ -34,15 +34,20 @@ Une extension qui fournit la coloration syntaxique et des extraits de code (snip
 
 ## Exécution des algorithmes
 
-Le dossier [`tools/`](tools/) contient `algotn.py`, un transpileur qui traduit
-les fichiers `.algo` en Python puis les exécute dans le terminal (Python 3.10+,
-aucune dépendance) :
+Cliquez sur le bouton **▶ Exécuter l'algorithme** en haut de l'éditeur (ou
+`Ctrl+F5`) : le fichier `.algo` est traduit en Python puis exécuté dans le
+terminal intégré. Seul **Python 3.10+** est requis ; s'il est introuvable,
+l'extension propose de le télécharger.
+
+En dehors de VSCode, le transpileur du dossier [`tools/`](tools/) s'utilise
+directement :
 
 ```console
 python tools/algotn.py mon_algo.algo
 ```
 
-Voir [tools/README.md](tools/README.md) pour la liste des structures supportées.
+Voir [tools/README.md](tools/README.md) pour la liste des structures supportées
+(fonctions, procédures avec `@`, tableaux de déclaration dessinés, etc.).
 
 ## Coloration Syntaxique
 

--- a/extension.js
+++ b/extension.js
@@ -1,0 +1,64 @@
+const vscode = require('vscode');
+const path = require('path');
+const { execFile } = require('child_process');
+
+// Vérifie qu'un interpréteur répond à --version (l'alias Microsoft Store
+// de python.exe sous Windows échoue ici, ce qui est le comportement voulu).
+function interpreteurValide(cmd) {
+    return new Promise(resolve => {
+        execFile(cmd, ['--version'], { timeout: 5000 }, err => resolve(!err));
+    });
+}
+
+async function trouverPython() {
+    const config = vscode.workspace.getConfiguration('algo').get('pythonPath', 'python');
+    const candidats = [config, 'python', 'py', 'python3']
+        .filter((c, i, a) => c && a.indexOf(c) === i);
+    for (const c of candidats) {
+        if (await interpreteurValide(c)) {
+            return c;
+        }
+    }
+    return null;
+}
+
+function activate(context) {
+    // Exécuter le fichier .algo courant avec le transpileur tools/algotn.py
+    context.subscriptions.push(
+        vscode.commands.registerCommand('algo.run', async () => {
+            const editor = vscode.window.activeTextEditor;
+            if (!editor || editor.document.languageId !== 'algo') {
+                vscode.window.showErrorMessage("Ouvrez un fichier .algo pour l'exécuter.");
+                return;
+            }
+            await editor.document.save();
+
+            const python = await trouverPython();
+            if (!python) {
+                const choix = await vscode.window.showErrorMessage(
+                    "Python est introuvable : il est nécessaire pour exécuter les algorithmes. "
+                    + "Installez-le (cochez « Add python.exe to PATH ») puis redémarrez VSCode, "
+                    + "ou indiquez son chemin dans le réglage « algo.pythonPath ».",
+                    'Télécharger Python', 'Ouvrir les réglages');
+                if (choix === 'Télécharger Python') {
+                    vscode.env.openExternal(vscode.Uri.parse('https://www.python.org/downloads/'));
+                } else if (choix === 'Ouvrir les réglages') {
+                    vscode.commands.executeCommand('workbench.action.openSettings', 'algo.pythonPath');
+                }
+                return;
+            }
+
+            const transpiler = context.asAbsolutePath(path.join('tools', 'algotn.py'));
+            let term = vscode.window.terminals.find(t => t.name === 'Algorithme');
+            if (!term) {
+                term = vscode.window.createTerminal('Algorithme');
+            }
+            term.show();
+            term.sendText(`${python} "${transpiler}" "${editor.document.fileName}"`);
+        })
+    );
+}
+
+function deactivate() { }
+
+module.exports = { activate, deactivate };

--- a/package.json
+++ b/package.json
@@ -11,7 +11,52 @@
     "categories": [
         "Programming Languages"
     ],
+    "main": "./extension.js",
+    "activationEvents": [
+        "onLanguage:algo"
+    ],
     "contributes": {
+        "commands": [
+            {
+                "command": "algo.run",
+                "title": "Exécuter l'algorithme",
+                "category": "Algorithme",
+                "icon": "$(play)"
+            }
+        ],
+        "menus": {
+            "editor/title": [
+                {
+                    "command": "algo.run",
+                    "when": "editorLangId == algo",
+                    "group": "navigation"
+                }
+            ],
+            "editor/context": [
+                {
+                    "command": "algo.run",
+                    "when": "editorLangId == algo",
+                    "group": "algo@1"
+                }
+            ]
+        },
+        "keybindings": [
+            {
+                "command": "algo.run",
+                "key": "ctrl+f5",
+                "when": "editorLangId == algo"
+            }
+        ],
+        "configuration": {
+            "title": "Algorithme-tn",
+            "properties": {
+                "algo.pythonPath": {
+                    "type": "string",
+                    "default": "python",
+                    "description": "Interpréteur Python utilisé pour exécuter les fichiers .algo (ex : python, python3, py)."
+                }
+            }
+        },
         "languages": [
             {
                 "id": "algo",

--- a/tools/README.md
+++ b/tools/README.md
@@ -12,12 +12,22 @@ python tools/algotn.py exemple.algo --no-run   # transpile sans exécuter
 
 ## Ce qui est supporté
 
-- `écrire`, `écrire_nl`, `lire` — la lecture est **typée selon le TDO** :
-  `n : entier` ⇒ `lire(n)` fait `int(input())` avec contrôle de saisie ;
+- `écrire`, `écrire_nl`, `lire` (alias `afficher`, `saisir`) — la lecture est
+  **typée selon les tableaux de déclaration** : `n : entier` ⇒ `lire(n)` fait
+  `int(input())` avec contrôle de saisie ; `caractère` = exactement 1 caractère ;
+- **les tableaux de déclaration dessinés** (TDO / TDOG / TDOL, snippets
+  `tdo-1`, `tdo-3`…) sont lus, où qu'ils soient dans le fichier ; un type
+  non défini y est signalé comme erreur ;
+- **`fonction` et `procédure`** définies par l'utilisateur, avec `retourner` ;
+  le passage par variable `@x` d'une procédure est émulé (la variable passée
+  est bien modifiée après l'appel) ; les paramètres typés dans l'en-tête
+  n'ont pas besoin d'être répétés dans le TDOL ;
 - `x ← expr` (ou `x <- expr`) ;
-- `si / sinon si / sinon / fin_si`, `pour … de … à … [pas …] faire`,
+- `si / sinon si / sinon / fin_si`, `pour … de … à … [pas …] faire`
+  (la borne finale est **atteinte**, contrairement au `range` de Python),
   `tant que … faire`, `répéter … jusqu'à`, `selon … autres … fin_selon` ;
-- `t : tableau de 10 entier` — tableaux indexés de 1 à n comme en cours ;
+- `t : tableau de 10 entier` et TDNT `tab = tableau de 20 entier` —
+  tableaux indexés de 1 à n comme en cours ;
 - opérateurs `= ≠ ≤ ≥ ∈ et ou non ouex div mod`, constantes `vrai`/`faux` ;
 - fonctions prédéfinies : `abs`, `ent`, `arrondi`, `racine_carrée`, `aléa`,
   `chr`, `ord`, `majus`, `convch`, `valeur`, `estnum`, `long`, `pos`,
@@ -25,9 +35,9 @@ python tools/algotn.py exemple.algo --no-run   # transpile sans exécuter
 - commentaires `//` et `/* … */` ;
 - les deux graphies : `écrire`/`Ecrire`, `fin_si`/`FinSi`, `à`/`A`, etc.
 
-Pas encore supporté : `fonction`/`procédure` définies par l'utilisateur,
-`enregistrement` (TDNT), fichiers texte et fichiers typés.
+Pas encore supporté : `enregistrement` (TDNT), fichiers texte et fichiers typés.
 
-Voir [`exemple.algo`](exemple.algo) et [`exemple2.algo`](exemple2.algo).
+Voir [`exemple.algo`](exemple.algo), [`exemple2.algo`](exemple2.algo) et
+[`exemple3.algo`](exemple3.algo) (fonctions, procédure avec `@`, TDOG/TDOL).
 
 Développement suivi sur [MajdLHB/algo-tn-compiler](https://github.com/MajdLHB/algo-tn-compiler).

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,33 @@
+# algotn.py — exécuter les fichiers `.algo`
+
+Un transpileur qui traduit le pseudocode de l'extension en **Python**, puis
+l'exécute dans le terminal. Aucune dépendance : il suffit de Python 3.10+.
+
+```console
+python tools/algotn.py exemple.algo            # transpile + exécute
+python tools/algotn.py exemple.algo --show     # affiche le Python généré
+python tools/algotn.py exemple.algo --out f.py # sauvegarde le Python généré
+python tools/algotn.py exemple.algo --no-run   # transpile sans exécuter
+```
+
+## Ce qui est supporté
+
+- `écrire`, `écrire_nl`, `lire` — la lecture est **typée selon le TDO** :
+  `n : entier` ⇒ `lire(n)` fait `int(input())` avec contrôle de saisie ;
+- `x ← expr` (ou `x <- expr`) ;
+- `si / sinon si / sinon / fin_si`, `pour … de … à … [pas …] faire`,
+  `tant que … faire`, `répéter … jusqu'à`, `selon … autres … fin_selon` ;
+- `t : tableau de 10 entier` — tableaux indexés de 1 à n comme en cours ;
+- opérateurs `= ≠ ≤ ≥ ∈ et ou non ouex div mod`, constantes `vrai`/`faux` ;
+- fonctions prédéfinies : `abs`, `ent`, `arrondi`, `racine_carrée`, `aléa`,
+  `chr`, `ord`, `majus`, `convch`, `valeur`, `estnum`, `long`, `pos`,
+  `sous_chaîne`, `effacer` (chaînes indexées à partir de 1) ;
+- commentaires `//` et `/* … */` ;
+- les deux graphies : `écrire`/`Ecrire`, `fin_si`/`FinSi`, `à`/`A`, etc.
+
+Pas encore supporté : `fonction`/`procédure` définies par l'utilisateur,
+`enregistrement` (TDNT), fichiers texte et fichiers typés.
+
+Voir [`exemple.algo`](exemple.algo) et [`exemple2.algo`](exemple2.algo).
+
+Développement suivi sur [MajdLHB/algo-tn-compiler](https://github.com/MajdLHB/algo-tn-compiler).

--- a/tools/algotn.py
+++ b/tools/algotn.py
@@ -1,0 +1,457 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+algotn — Transpileur / exécuteur de pseudocode tunisien vers Python.
+
+Syntaxe supportée : le pseudocode de l'enseignement secondaire tunisien,
+tel que défini par l'extension VSCode "Algorithme en Pseudocode" (algorithme-tn)
+https://marketplace.visualstudio.com/items?itemName=hamdi-bergaoui.algorithme-tn
+
+Usage :
+    python algotn.py fichier.algo            # transpile + exécute
+    python algotn.py fichier.algo --show     # affiche aussi le code Python généré
+    python algotn.py fichier.algo --out f.py # sauvegarde le Python généré
+    python algotn.py fichier.algo --no-run   # transpile sans exécuter
+"""
+
+import re
+import sys
+import unicodedata
+
+# ---------------------------------------------------------------------------
+# Runtime : fonctions prédéfinies du pseudocode, injectées dans le programme
+# généré. Les chaînes du pseudocode sont indexées à partir de 1.
+# ---------------------------------------------------------------------------
+RUNTIME = '''\
+import math as _math
+import random as _random
+import sys as _sys
+try:
+    _sys.stdout.reconfigure(encoding="utf-8")
+    _sys.stderr.reconfigure(encoding="utf-8")
+    if not _sys.stdin.isatty():
+        _sys.stdin.reconfigure(encoding="utf-8-sig")
+except Exception:
+    pass
+
+def _input():
+    return input().strip().lstrip("\\ufeff")
+
+def _lire():
+    # variable non déclarée : détection automatique du type
+    s = _input()
+    try:
+        return int(s)
+    except ValueError:
+        pass
+    try:
+        return float(s.replace(",", "."))
+    except ValueError:
+        pass
+    low = s.strip().lower()
+    if low == "vrai":
+        return True
+    if low == "faux":
+        return False
+    return s
+
+def _lire_entier():
+    while True:
+        try:
+            return int(_input())
+        except ValueError:
+            print("Valeur invalide, un entier est attendu. Refaire : ", end="")
+
+def _lire_reel():
+    while True:
+        try:
+            return float(_input().replace(",", "."))
+        except ValueError:
+            print("Valeur invalide, un réel est attendu. Refaire : ", end="")
+
+def _lire_chaine():
+    return input()
+
+def _lire_booleen():
+    while True:
+        s = _input().lower()
+        if s in ("vrai", "true", "1"):
+            return True
+        if s in ("faux", "false", "0"):
+            return False
+        print("Valeur invalide, vrai ou faux attendu. Refaire : ", end="")
+
+def _ecrire(*args):
+    print(*args, sep="")
+
+def _ecrire_nl(*args):
+    print(*args, sep="")
+
+def ent(x):
+    return _math.floor(x)
+
+def arrondi(x, n=0):
+    r = round(x, int(n))
+    return int(r) if n == 0 else r
+
+def racine_carree(x):
+    return _math.sqrt(x)
+
+def alea(a, b):
+    return _random.randint(a, b)
+
+def majus(ch):
+    return ch.upper()
+
+def convch(x):
+    if isinstance(x, bool):
+        return "vrai" if x else "faux"
+    return str(x)
+
+def valeur(ch):
+    try:
+        return int(ch), 0
+    except ValueError:
+        pass
+    try:
+        return float(ch.replace(",", ".")), 0
+    except ValueError:
+        return 0, 1
+
+def estnum(ch):
+    return valeur(ch)[1] == 0
+
+def long(ch):
+    return len(ch)
+
+def pos(ch1, ch2):
+    return ch2.find(ch1) + 1
+
+def sous_chaine(ch, d, f):
+    return ch[d - 1:f]
+
+def effacer(ch, p, n):
+    return ch[:p - 1] + ch[p - 1 + n:]
+
+def _tableau(n, defaut):
+    return [defaut] * (n + 1)  # indice 0 inutilisé : indexation 1..n
+'''
+
+DEFAULTS = {
+    "entier": "0", "reel": "0.0", "booleen": "False",
+    "caractere": '""', "chaine": '""',
+}
+
+
+def strip_accents(s: str) -> str:
+    return "".join(c for c in unicodedata.normalize("NFD", s)
+                   if unicodedata.category(c) != "Mn")
+
+
+class TranspileError(Exception):
+    pass
+
+
+class Transpiler:
+    def __init__(self):
+        self.out = []
+        self.indent = 0
+        # pile des blocs ouverts : 'si', 'pour', 'tant_que', 'repeter', 'selon'
+        self.stack = []
+        self.strings = []
+        # table des symboles issue du TDO : nom (minuscules) -> type déclaré
+        self.types = {}
+
+    # -- protection des chaînes littérales ----------------------------------
+    def _shelve_strings(self, line: str) -> str:
+        def repl(m):
+            self.strings.append(m.group(0))
+            return f"\x00{len(self.strings) - 1}\x00"
+        return re.sub(r'"[^"]*"|\'[^\']*\'', repl, line)
+
+    def _unshelve_strings(self, line: str) -> str:
+        return re.sub(r"\x00(\d+)\x00",
+                      lambda m: self.strings[int(m.group(1))], line)
+
+    # -- traduction des expressions ------------------------------------------
+    def expr(self, e: str, cond: bool = True) -> str:
+        e = e.strip()
+        # opérateurs symboliques
+        e = e.replace("←", "=").replace("<-", "=")
+        e = e.replace("≠", "!=").replace("≤", "<=").replace("≥", ">=")
+        e = e.replace("∈", " in ")
+        # =  →  ==  (l'affectation utilise ← ; un = restant est une comparaison)
+        if cond:
+            e = re.sub(r"(?<![<>!=])=(?!=)", "==", e)
+        # mots-clés logiques / arithmétiques / constantes
+        words = {
+            "et": "and", "ou": "or", "non": "not", "ouex": "^",
+            "div": "//", "mod": "%", "vrai": "True", "faux": "False",
+            "dans": "in",
+        }
+        for w, py in words.items():
+            e = re.sub(rf"(?i)(?<![\w\x00]){w}(?![\w\x00])", py, e)
+        # fonctions prédéfinies (formes accentuées → runtime sans accents)
+        funcs = {
+            "racine_carree": "racine_carree", "alea": "alea",
+            "sous_chaine": "sous_chaine", "ecrire_nl": "_ecrire_nl",
+            "ecrire": "_ecrire",
+        }
+        def f_repl(m):
+            name = strip_accents(m.group(0)).lower()
+            return funcs.get(name, name)
+        e = re.sub(r"(?i)[\wÀ-ſ_]+(?=\s*\()", f_repl, e)
+        return e.strip()
+
+    # -- émission -------------------------------------------------------------
+    def emit(self, code: str):
+        self.out.append("    " * self.indent + self._unshelve_strings(code))
+
+    def close(self, kinds, mot: str, num: int):
+        if not self.stack or self.stack[-1] not in kinds:
+            raise TranspileError(f"ligne {num}: « {mot} » sans bloc ouvert correspondant")
+        self.stack.pop()
+        self.indent -= 1
+
+    # -- transpilation ---------------------------------------------------------
+    def transpile(self, source: str) -> str:
+        # commentaires /* ... */ (multi-lignes)
+        source = re.sub(r"/\*.*?\*/", "", source, flags=re.S)
+        self.out = [RUNTIME]
+
+        for num, raw in enumerate(source.splitlines(), 1):
+            line = self._shelve_strings(raw)
+            line = re.sub(r"//.*", "", line).strip()   # commentaires //
+            if not line:
+                continue
+            norm = strip_accents(line).lower()
+
+            # --- en-tête / structure ------------------------------------------
+            if re.match(r"(algorithme|programme)\b", norm):
+                self.emit("# " + line)
+                continue
+            if norm in ("debut", "début"):
+                continue
+            if re.match(r"fin\s*$", norm) or re.match(r"fin\s+\w+\s*$", norm) \
+                    and not norm.startswith(("fin_", "fin si", "fin pour",
+                                             "fin tant", "fin selon")):
+                if self.stack:
+                    raise TranspileError(
+                        f"ligne {num}: « fin » atteint mais bloc « {self.stack[-1]} » non fermé")
+                continue
+
+            # --- déclarations (TDO) --------------------------------------------
+            m = re.match(r"(?i)(?:var\s+)?([\wÀ-ſ, ]+?)\s*:\s*tableau\s+de\s+(\w+)\s+([\wÀ-ſ]+)",
+                         line.strip())
+            if m:
+                names = [n.strip() for n in m.group(1).split(",")]
+                size, typ = m.group(2), strip_accents(m.group(3)).lower()
+                default = DEFAULTS.get(typ, "0")
+                for n in names:
+                    self.types[strip_accents(n).lower()] = typ
+                    self.emit(f"{n} = _tableau({size}, {default})")
+                continue
+            m = re.match(r"(?i)(?:var\s+)?([\wÀ-ſ, ]+?)\s*:\s*([\wÀ-ſ]+)\s*$", line.strip())
+            if m and strip_accents(m.group(2)).lower() in DEFAULTS:
+                # déclaration simple (TDO) : mémoriser le type pour lire()
+                typ = strip_accents(m.group(2)).lower()
+                for n in m.group(1).split(","):
+                    self.types[strip_accents(n).lower().strip()] = typ
+                continue
+            if norm in ("var", "objet", "objets", "constantes", "types"):
+                continue
+
+            # --- si / sinon si / sinon / fin_si --------------------------------
+            m = re.match(r"si\s+(.*?)\s+alors\s*$", norm)
+            if m:
+                cond = self._cut(line, r"(?i)^si\s+", r"(?i)\s+alors\s*$")
+                self.emit(f"if {self.expr(cond)}:")
+                self.stack.append("si")
+                self.indent += 1
+                continue
+            m = re.match(r"sinon\s+si\s+(.*?)\s+alors\s*$", norm)
+            if m:
+                cond = self._cut(line, r"(?i)^sinon\s+si\s+", r"(?i)\s+alors\s*$")
+                self.indent -= 1
+                self.emit(f"elif {self.expr(cond)}:")
+                self.indent += 1
+                continue
+            if norm in ("sinon", "sinon:"):
+                self.indent -= 1
+                self.emit("else:")
+                self.indent += 1
+                continue
+            if re.match(r"(fin_si|finsi|fin\s+si)\s*$", norm):
+                self.close(("si",), "fin_si", num)
+                continue
+
+            # --- pour ... de ... à ... [pas ...] faire --------------------------
+            m = re.match(
+                r"pour\s+([\wÀ-ſ]+)\s+(?:de|allant\s+de)\s+(.+?)\s+(?:a|à|jusqu'a|jusqu'à)\s+(.+?)(?:\s+pas\s+(.+?))?\s*(?:faire)?\s*$",
+                norm)
+            if m:
+                mo = re.match(
+                    r"(?i)pour\s+([\wÀ-ſ]+)\s+(?:de|allant\s+de)\s+(.+?)\s+(?:a|à|jusqu'a|jusqu'à)\s+(.+?)(?:\s+pas\s+(.+?))?\s*(?:faire)?\s*$",
+                    line.strip())
+                var, start, stop, step = mo.group(1), mo.group(2), mo.group(3), mo.group(4)
+                start, stop = self.expr(start, cond=False), self.expr(stop, cond=False)
+                if step:
+                    step = self.expr(step, cond=False)
+                    limit = f"({stop}) + (1 if ({step}) > 0 else -1)"
+                    self.emit(f"for {var} in range({start}, {limit}, {step}):")
+                else:
+                    self.emit(f"for {var} in range({start}, ({stop}) + 1):")
+                self.stack.append("pour")
+                self.indent += 1
+                continue
+            if re.match(r"(fin_pour|finpour|fin\s+pour)\s*$", norm):
+                self.close(("pour",), "fin_pour", num)
+                continue
+
+            # --- tant que ... faire ---------------------------------------------
+            m = re.match(r"tant\s*_?\s*que\s+(.*?)\s*(?:faire)?\s*$", norm)
+            if m:
+                cond = self._cut(line, r"(?i)^tant\s*_?\s*que\s+", r"(?i)\s+faire\s*$")
+                self.emit(f"while {self.expr(cond)}:")
+                self.stack.append("tant_que")
+                self.indent += 1
+                continue
+            if re.match(r"(fin_tant_que|fintantque|fin\s+tant\s*_?\s*que)\s*$", norm):
+                self.close(("tant_que",), "fin_tant_que", num)
+                continue
+
+            # --- répéter ... jusqu'à --------------------------------------------
+            if re.match(r"(repeter|répéter)\s*$", norm):
+                self.emit("while True:")
+                self.stack.append("repeter")
+                self.indent += 1
+                continue
+            m = re.match(r"jusqu'?\s*a\s+(.+)$", norm)
+            if m:
+                cond = self._cut(line, r"(?i)^jusqu'?\s*(a|à)\s+", r"$")
+                self.emit(f"if {self.expr(cond)}:")
+                self.emit(f"    break")
+                self.close(("repeter",), "jusqu'à", num)
+                continue
+
+            # --- selon ... fin_selon ---------------------------------------------
+            m = re.match(r"selon\s+(.+?)\s*(?:faire)?\s*$", norm)
+            if m:
+                sel = self._cut(line, r"(?i)^selon\s+", r"(?i)\s+faire\s*$")
+                self.emit(f"match {self.expr(sel, cond=False)}:")
+                self.stack.append("selon")
+                self.indent += 1
+                self._selon_open = False
+                continue
+            if re.match(r"(fin_selon|finselon|fin\s+selon)\s*$", norm):
+                if getattr(self, "_selon_open", False):
+                    self.indent -= 1
+                    self._selon_open = False
+                self.close(("selon",), "fin_selon", num)
+                continue
+            if self.stack and self.stack[-1] == "selon":
+                m = re.match(r"(.+?)\s*:\s*(.*)$", line.strip())
+                if m:
+                    if getattr(self, "_selon_open", False):
+                        self.indent -= 1
+                    values, rest = m.group(1), m.group(2)
+                    if strip_accents(values).lower().strip() in ("autres", "autre", "sinon"):
+                        self.emit("case _:")
+                    else:
+                        alts = " | ".join(self.expr(v, cond=False)
+                                          for v in values.split(","))
+                        self.emit(f"case {alts}:")
+                    self.indent += 1
+                    self._selon_open = True
+                    if rest.strip():
+                        self._statement(rest, num)
+                    continue
+
+            # --- instruction simple -----------------------------------------------
+            self._statement(line, num)
+
+        if self.stack:
+            raise TranspileError(f"fin de fichier : bloc « {self.stack[-1]} » non fermé")
+        return "\n".join(self._unshelve_strings(l) if "\x00" in l else l
+                         for l in self.out) + "\n"
+
+    def _cut(self, line: str, prefix: str, suffix: str) -> str:
+        s = line.strip()
+        s = re.sub(prefix, "", s)
+        s = re.sub(suffix, "", s)
+        return s
+
+    def _statement(self, line: str, num: int):
+        norm = strip_accents(line).lower().strip()
+        # lire(a, b, ...)
+        m = re.match(r"lire\s*\((.+)\)\s*$", norm)
+        if m:
+            readers = {"entier": "_lire_entier", "reel": "_lire_reel",
+                       "chaine": "_lire_chaine", "caractere": "_lire_chaine",
+                       "booleen": "_lire_booleen"}
+            inner = re.match(r"(?i)lire\s*\((.+)\)\s*$", line.strip()).group(1)
+            for v in inner.split(","):
+                # type déclaré dans le TDO → lecture typée (t[i] → type de t)
+                base = strip_accents(v).lower().strip().split("[")[0].strip()
+                fn = readers.get(self.types.get(base), "_lire")
+                self.emit(f"{self.expr(v, cond=False)} = {fn}()")
+            return
+        # écrire(...) / écrire_nl(...)
+        m = re.match(r"(ecrire_nl|ecrire)\s*\((.*)\)\s*$", norm)
+        if m:
+            fn = "_ecrire_nl" if m.group(1) == "ecrire_nl" else "_ecrire"
+            inner = re.match(r"(?i)[\wÀ-ſ_]+\s*\((.*)\)\s*$", line.strip()).group(1)
+            self.emit(f"{fn}({self.expr(inner, cond=False)})")
+            return
+        # affectation x ← expr  (ou instruction quelconque)
+        if "←" in line or "<-" in line:
+            lhs, rhs = re.split(r"←|<-", line, maxsplit=1)
+            self.emit(f"{self.expr(lhs, cond=False)} = {self.expr(rhs, cond=False)}")
+            return
+        self.emit(self.expr(line, cond=False))
+
+
+def main():
+    try:
+        sys.stdout.reconfigure(encoding="utf-8")
+        sys.stderr.reconfigure(encoding="utf-8")
+    except Exception:
+        pass
+    args = [a for a in sys.argv[1:]]
+    if not args or args[0] in ("-h", "--help"):
+        print(__doc__)
+        sys.exit(0)
+    path = args[0]
+    show = "--show" in args
+    run = "--no-run" not in args
+    out_file = None
+    if "--out" in args:
+        out_file = args[args.index("--out") + 1]
+
+    try:
+        with open(path, encoding="utf-8") as f:
+            source = f.read()
+    except FileNotFoundError:
+        print(f"Erreur : fichier introuvable : {path}")
+        sys.exit(1)
+
+    try:
+        py = Transpiler().transpile(source)
+    except TranspileError as e:
+        print(f"Erreur de transpilation — {e}")
+        sys.exit(1)
+
+    if show:
+        print("─" * 50)
+        print(py)
+        print("─" * 50)
+    if out_file:
+        with open(out_file, "w", encoding="utf-8") as f:
+            f.write(py)
+        print(f"Python généré → {out_file}")
+    if run:
+        exec(compile(py, path, "exec"), {"__name__": "__main__"})
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/algotn.py
+++ b/tools/algotn.py
@@ -156,6 +156,21 @@ def strip_accents(s: str) -> str:
                    if unicodedata.category(c) != "Mn")
 
 
+def parse_param(p: str):
+    """Paramètre formel : 'n : entier', 'entier n', '@n : entier', 'var n : entier'
+    -> (nom, type ou None, passage_par_variable)"""
+    p = p.strip()
+    ref = "@" in p or bool(re.match(r"(?i)var\s", p))
+    p = re.sub(r"(?i)^var\s+", "", p).replace("@", "").strip()
+    if ":" in p:
+        name, typ = p.split(":", 1)
+        return strip_accents(name).lower().strip(), typ.strip(), ref
+    words = p.split()
+    if len(words) == 2 and strip_accents(words[0]).lower() in DEFAULTS:
+        return strip_accents(words[1]).lower().strip(), words[0], ref
+    return strip_accents(p).lower().strip(), None, ref
+
+
 class TranspileError(Exception):
     pass
 
@@ -206,13 +221,20 @@ class Transpiler:
                 self.types[n] = elem
                 init = f"{n} = _tableau({size}, {DEFAULTS[elem]})"
                 if self._registering:
-                    self._pending_arrays.append(init)
+                    self._pending_inits.append(init)
                 elif emit_arrays:
                     self.emit(init)
             return
         if t in DEFAULTS:
             for n in names:
                 self.types[n] = t
+                if n in self.procs:
+                    continue  # variable résultat portant le nom de la fonction
+                init = f"{n} = {DEFAULTS[t]}"
+                if self._registering:
+                    self._pending_inits.append(init)
+                elif emit_arrays:
+                    self.emit(init)
             return
         if t in ("fonction", "procedure") or t.startswith("fichier") \
                 or t.startswith("constante"):
@@ -309,15 +331,9 @@ class Transpiler:
         source = re.sub(r"/\*.*?\*/", "", source, flags=re.S)
         self.out = []
 
-        # passe 1 : tableaux de déclaration (peuvent suivre le code) et
-        # signatures des sous-programmes (@ = passage par variable)
+        # passe 1a : signatures des sous-programmes (@ = passage par variable)
         self.procs = {}
-        self._registering = True
-        self._pending_arrays = []
-        for num, l in enumerate(source.splitlines(), 1):
-            if l.strip().startswith("│"):
-                self._table_row(self._shelve_strings(l.strip()), num)
-                continue
+        for l in source.splitlines():
             m = re.match(
                 r"(?i)^\s*(fonction|fn|procedure|procédure|proc)\s+([\wÀ-ſ]+)\s*\((.*)\)",
                 l)
@@ -327,19 +343,23 @@ class Transpiler:
                         else "procedure")
                 refs, params = [], []
                 for p in re.split(r"[;,]", m.group(3)):
-                    p = p.strip()
-                    if not p or ":" in p and not p.split(":")[0].strip():
+                    if not p.strip():
                         continue
-                    pname = p.split(":")[0].strip()
-                    refs.append(pname.startswith("@")
-                                or bool(re.match(r"(?i)var\s", p)))
-                    params.append(strip_accents(pname).lower()
-                                  .lstrip("@").replace("var ", "").strip())
+                    name, _typ, ref = parse_param(p)
+                    params.append(name)
+                    refs.append(ref)
                 self.procs[strip_accents(m.group(2)).lower()] = {
                     "kind": kind, "refs": refs, "params": params}
+
+        # passe 1b : tableaux de déclaration dessinés (peuvent suivre le code)
+        self._registering = True
+        self._pending_inits = []
+        for num, l in enumerate(source.splitlines(), 1):
+            if l.strip().startswith("│"):
+                self._table_row(self._shelve_strings(l.strip()), num)
         self._registering = False
-        # les tableaux déclarés dans un TDO/TDOG/TDOL sont initialisés en tête
-        self.out.extend(self._pending_arrays)
+        # les objets déclarés dans un TDO/TDOG/TDOL sont initialisés en tête
+        self.out.extend(self._pending_inits)
 
         for num, raw in enumerate(source.splitlines(), 1):
             line = self._shelve_strings(raw)
@@ -365,15 +385,12 @@ class Transpiler:
                 name = strip_accents(m.group(2)).lower()
                 params = []
                 for p in re.split(r"[;,]", m.group(3)):
-                    p = p.strip()
-                    if not p:
+                    if not p.strip():
                         continue
-                    p = re.sub(r"(?i)^var\s+", "", p).lstrip("@")
-                    pname = p.split(":")[0].strip()
-                    params.append(strip_accents(pname).lower())
-                    if ":" in p:
-                        self._declare([pname], p.split(":", 1)[1], num,
-                                      emit_arrays=False)
+                    pname, ptyp, _ = parse_param(p)
+                    params.append(pname)
+                    if ptyp:
+                        self._declare([pname], ptyp, num, emit_arrays=False)
                 self.in_def = True
                 self._cur_def = self.procs.get(name)
                 self._saved_indent = self.indent
@@ -436,12 +453,20 @@ class Transpiler:
                 continue
             m = re.match(r"sinon\s+si\s+(.*?)\s+alors\s*$", norm)
             if m:
+                if not self.stack or self.stack[-1] != "si":
+                    raise TranspileError(
+                        f"ligne {num}: « sinon si » sans « si » ouvert "
+                        "(fin_si placé trop tôt ?)")
                 cond = self._cut(line, r"(?i)^sinon\s+si\s+", r"(?i)\s+alors\s*$")
                 self.indent -= 1
                 self.emit(f"elif {self.expr(cond)}:")
                 self.indent += 1
                 continue
             if norm in ("sinon", "sinon:"):
+                if not self.stack or self.stack[-1] != "si":
+                    raise TranspileError(
+                        f"ligne {num}: « sinon » sans « si » ouvert "
+                        "(fin_si placé trop tôt ?)")
                 self.indent -= 1
                 self.emit("else:")
                 self.indent += 1
@@ -460,12 +485,14 @@ class Transpiler:
                     line.strip())
                 var, start, stop, step = mo.group(1), mo.group(2), mo.group(3), mo.group(4)
                 start, stop = self.expr(start, cond=False), self.expr(stop, cond=False)
+                # bornes incluses (contrairement à range), et int() car une
+                # borne peut être réelle (ex : pour i de 2 à racine_carrée(n))
                 if step:
                     step = self.expr(step, cond=False)
-                    limit = f"({stop}) + (1 if ({step}) > 0 else -1)"
-                    self.emit(f"for {var} in range({start}, {limit}, {step}):")
+                    limit = f"int({stop}) + (1 if ({step}) > 0 else -1)"
+                    self.emit(f"for {var} in range(int({start}), {limit}, int({step})):")
                 else:
-                    self.emit(f"for {var} in range({start}, ({stop}) + 1):")
+                    self.emit(f"for {var} in range(int({start}), int({stop}) + 1):")
                 self.stack.append("pour")
                 self.indent += 1
                 continue
@@ -640,8 +667,17 @@ def main():
         with open(out_file, "w", encoding="utf-8") as f:
             f.write(py)
         print(f"Python généré → {out_file}")
+
+    try:
+        code = compile(py, path, "exec")
+    except SyntaxError as e:
+        print("Erreur de syntaxe — cette ligne n'a pas été comprise :")
+        print(f"    {(e.text or '').strip()}")
+        print("Vérifiez l'orthographe des mots-clés (algorithme, si, pour, "
+              "fonction, procédure...) et la structure de la ligne.")
+        sys.exit(1)
     if run:
-        exec(compile(py, path, "exec"), {"__name__": "__main__"})
+        exec(code, {"__name__": "__main__"})
 
 
 if __name__ == "__main__":

--- a/tools/algotn.py
+++ b/tools/algotn.py
@@ -72,6 +72,14 @@ def _lire_reel():
 def _lire_chaine():
     return input()
 
+def _lire_caractere():
+    # un caractère = une chaîne d'un seul élément
+    while True:
+        s = _input()
+        if len(s) == 1:
+            return s
+        print("Valeur invalide, un seul caractère est attendu. Refaire : ", end="")
+
 def _lire_booleen():
     while True:
         s = _input().lower()
@@ -156,11 +164,19 @@ class Transpiler:
     def __init__(self):
         self.out = []
         self.indent = 0
-        # pile des blocs ouverts : 'si', 'pour', 'tant_que', 'repeter', 'selon'
+        # pile des blocs ouverts : 'si', 'pour', 'tant_que', 'repeter',
+        # 'selon', 'sousprog' (fonction/procédure)
         self.stack = []
         self.strings = []
         # table des symboles issue du TDO : nom (minuscules) -> type déclaré
         self.types = {}
+        # nouveaux types (TDNT) : nom -> ("tableau", taille, type_éléments)
+        self.newtypes = {}
+        # sous-programmes : le code des fonctions/procédures est émis à part
+        self.defs = []
+        self.in_def = False
+        self.procs = {}
+        self._cur_def = None
 
     # -- protection des chaînes littérales ----------------------------------
     def _shelve_strings(self, line: str) -> str:
@@ -173,9 +189,82 @@ class Transpiler:
         return re.sub(r"\x00(\d+)\x00",
                       lambda m: self.strings[int(m.group(1))], line)
 
+    # -- déclarations (TDO / TDOG / TDOL / TDNT) -------------------------------
+    def _declare(self, names, typ_raw, num, emit_arrays=True):
+        t = re.sub(r"\s+", " ", strip_accents(str(typ_raw)).lower().strip())
+        names = [strip_accents(n).lower().strip().lstrip("@")
+                 for n in names if n.strip()]
+        if t in self.newtypes:
+            t = self.newtypes[t]
+        m = re.match(r"tableau de (\w+) ([\wÀ-ſ ]+)$", t)
+        if m:
+            size, elem = m.group(1), m.group(2).strip()
+            if elem not in DEFAULTS:
+                raise TranspileError(
+                    f"ligne {num}: type non défini « {typ_raw.strip()} »")
+            for n in names:
+                self.types[n] = elem
+                init = f"{n} = _tableau({size}, {DEFAULTS[elem]})"
+                if self._registering:
+                    self._pending_arrays.append(init)
+                elif emit_arrays:
+                    self.emit(init)
+            return
+        if t in DEFAULTS:
+            for n in names:
+                self.types[n] = t
+            return
+        if t in ("fonction", "procedure") or t.startswith("fichier") \
+                or t.startswith("constante"):
+            return  # déclarés dans le TDO, définis ailleurs
+        raise TranspileError(
+            f"ligne {num}: type non défini « {typ_raw.strip()} » — types valides : "
+            "entier, réel, booléen, caractère, chaîne, tableau de N type, "
+            "ou un nouveau type du TDNT")
+
+    def _table_row(self, line: str, num: int):
+        cells = [self._unshelve_strings(c).strip()
+                 for c in line.strip().strip("│").split("│")]
+        if not any(cells):
+            return
+        joined = strip_accents(" ".join(cells)).lower()
+        # lignes d'en-tête / de titre du tableau
+        if ("objet" in joined and ("nature" in joined or "type" in joined)) \
+                or "nouveaux types" in joined or "declaration" in joined:
+            return
+        # TDNT : nom = tableau de N type
+        m = re.match(r"(?i)^([\wÀ-ſ]+)\s*=\s*(tableau\s+de\s+.+)$", cells[0])
+        if m:
+            self.newtypes[strip_accents(m.group(1)).lower()] = re.sub(
+                r"\s+", " ", strip_accents(m.group(2)).lower().strip())
+            return
+        # TDO / TDOG / TDOL : objet(s) | type
+        if len(cells) >= 2 and cells[0] and cells[1]:
+            self._declare(cells[0].split(","), cells[1], num)
+            return
+        # enregistrements et autres lignes : non supportés, ignorés
+
+    def _split_args(self, s: str):
+        args, depth, cur = [], 0, ""
+        for c in s:
+            if c in "([":
+                depth += 1
+            elif c in ")]":
+                depth -= 1
+            if c == "," and depth == 0:
+                args.append(cur)
+                cur = ""
+            else:
+                cur += c
+        if cur.strip():
+            args.append(cur)
+        return args
+
     # -- traduction des expressions ------------------------------------------
     def expr(self, e: str, cond: bool = True) -> str:
         e = e.strip()
+        # @x (passage par variable) : sans objet côté Python
+        e = e.replace("@", "")
         # opérateurs symboliques
         e = e.replace("←", "=").replace("<-", "=")
         e = e.replace("≠", "!=").replace("≤", "<=").replace("≥", ">=")
@@ -205,7 +294,8 @@ class Transpiler:
 
     # -- émission -------------------------------------------------------------
     def emit(self, code: str):
-        self.out.append("    " * self.indent + self._unshelve_strings(code))
+        target = self.defs if self.in_def else self.out
+        target.append("    " * self.indent + self._unshelve_strings(code))
 
     def close(self, kinds, mot: str, num: int):
         if not self.stack or self.stack[-1] not in kinds:
@@ -217,7 +307,39 @@ class Transpiler:
     def transpile(self, source: str) -> str:
         # commentaires /* ... */ (multi-lignes)
         source = re.sub(r"/\*.*?\*/", "", source, flags=re.S)
-        self.out = [RUNTIME]
+        self.out = []
+
+        # passe 1 : tableaux de déclaration (peuvent suivre le code) et
+        # signatures des sous-programmes (@ = passage par variable)
+        self.procs = {}
+        self._registering = True
+        self._pending_arrays = []
+        for num, l in enumerate(source.splitlines(), 1):
+            if l.strip().startswith("│"):
+                self._table_row(self._shelve_strings(l.strip()), num)
+                continue
+            m = re.match(
+                r"(?i)^\s*(fonction|fn|procedure|procédure|proc)\s+([\wÀ-ſ]+)\s*\((.*)\)",
+                l)
+            if m:
+                kind = ("fonction"
+                        if strip_accents(m.group(1)).lower() in ("fonction", "fn")
+                        else "procedure")
+                refs, params = [], []
+                for p in re.split(r"[;,]", m.group(3)):
+                    p = p.strip()
+                    if not p or ":" in p and not p.split(":")[0].strip():
+                        continue
+                    pname = p.split(":")[0].strip()
+                    refs.append(pname.startswith("@")
+                                or bool(re.match(r"(?i)var\s", p)))
+                    params.append(strip_accents(pname).lower()
+                                  .lstrip("@").replace("var ", "").strip())
+                self.procs[strip_accents(m.group(2)).lower()] = {
+                    "kind": kind, "refs": refs, "params": params}
+        self._registering = False
+        # les tableaux déclarés dans un TDO/TDOG/TDOL sont initialisés en tête
+        self.out.extend(self._pending_arrays)
 
         for num, raw in enumerate(source.splitlines(), 1):
             line = self._shelve_strings(raw)
@@ -225,6 +347,41 @@ class Transpiler:
             if not line:
                 continue
             norm = strip_accents(line).lower()
+
+            # --- tableaux dessinés : TDO / TDOG / TDOL / TDNT -------------------
+            if re.match(r"^[┌├└┬┴┼─]", line):
+                continue                       # bordure du tableau
+            if line.startswith("│"):
+                continue                       # ligne déjà traitée en passe 1
+
+            # --- fonction / procédure -------------------------------------------
+            m = re.match(
+                r"(?i)^(fonction|fn|procedure|procédure|proc)\s+([\wÀ-ſ]+)\s*\((.*)\)\s*(?::\s*([\wÀ-ſ ]+))?\s*$",
+                line.strip())
+            if m and strip_accents(m.group(1)).lower() in ("fonction", "fn", "procedure", "proc"):
+                if self.in_def:
+                    raise TranspileError(
+                        f"ligne {num}: sous-programme imbriqué non supporté")
+                name = strip_accents(m.group(2)).lower()
+                params = []
+                for p in re.split(r"[;,]", m.group(3)):
+                    p = p.strip()
+                    if not p:
+                        continue
+                    p = re.sub(r"(?i)^var\s+", "", p).lstrip("@")
+                    pname = p.split(":")[0].strip()
+                    params.append(strip_accents(pname).lower())
+                    if ":" in p:
+                        self._declare([pname], p.split(":", 1)[1], num,
+                                      emit_arrays=False)
+                self.in_def = True
+                self._cur_def = self.procs.get(name)
+                self._saved_indent = self.indent
+                self.indent = 0
+                self.emit(f"def {name}({', '.join(params)}):")
+                self.indent = 1
+                self.stack.append("sousprog")
+                continue
 
             # --- en-tête / structure ------------------------------------------
             if re.match(r"(algorithme|programme)\b", norm):
@@ -235,28 +392,36 @@ class Transpiler:
             if re.match(r"fin\s*$", norm) or re.match(r"fin\s+\w+\s*$", norm) \
                     and not norm.startswith(("fin_", "fin si", "fin pour",
                                              "fin tant", "fin selon")):
+                if self.stack and self.stack[-1] == "sousprog":
+                    self.stack.pop()
+                    info = self._cur_def
+                    # procédure : les paramètres @ sont renvoyés puis réaffectés
+                    # à l'appel (émulation du passage par variable)
+                    if info and info["kind"] == "procedure" and any(info["refs"]):
+                        refp = [p for p, r in zip(info["params"], info["refs"]) if r]
+                        self.indent = 1
+                        self.emit(f"return {', '.join(refp)}")
+                    self.in_def = False
+                    self.indent = self._saved_indent
+                    continue
                 if self.stack:
                     raise TranspileError(
                         f"ligne {num}: « fin » atteint mais bloc « {self.stack[-1]} » non fermé")
                 continue
 
             # --- déclarations (TDO) --------------------------------------------
-            m = re.match(r"(?i)(?:var\s+)?([\wÀ-ſ, ]+?)\s*:\s*tableau\s+de\s+(\w+)\s+([\wÀ-ſ]+)",
-                         line.strip())
-            if m:
-                names = [n.strip() for n in m.group(1).split(",")]
-                size, typ = m.group(2), strip_accents(m.group(3)).lower()
-                default = DEFAULTS.get(typ, "0")
-                for n in names:
-                    self.types[strip_accents(n).lower()] = typ
-                    self.emit(f"{n} = _tableau({size}, {default})")
+            m = re.match(
+                r"(?i)^(?:var\s+)?([@\wÀ-ſ]+(?:\s*,\s*[@\wÀ-ſ]+)*)\s*:\s*([\wÀ-ſ][\wÀ-ſ' .]*?)\s*$",
+                line.strip())
+            if m and not (self.stack and self.stack[-1] == "selon") \
+                    and not re.match(r"^\d", m.group(1)):
+                # déclaration (TDO) : type validé, mémorisé pour lire()
+                self._declare(m.group(1).split(","), m.group(2), num)
                 continue
-            m = re.match(r"(?i)(?:var\s+)?([\wÀ-ſ, ]+?)\s*:\s*([\wÀ-ſ]+)\s*$", line.strip())
-            if m and strip_accents(m.group(2)).lower() in DEFAULTS:
-                # déclaration simple (TDO) : mémoriser le type pour lire()
-                typ = strip_accents(m.group(2)).lower()
-                for n in m.group(1).split(","):
-                    self.types[strip_accents(n).lower().strip()] = typ
+            m = re.match(r"(?i)^([\wÀ-ſ]+)\s*=\s*(tableau\s+de\s+.+)$", line.strip())
+            if m:
+                self.newtypes[strip_accents(m.group(1)).lower()] = re.sub(
+                    r"\s+", " ", strip_accents(m.group(2)).lower().strip())
                 continue
             if norm in ("var", "objet", "objets", "constantes", "types"):
                 continue
@@ -372,8 +537,11 @@ class Transpiler:
 
         if self.stack:
             raise TranspileError(f"fin de fichier : bloc « {self.stack[-1]} » non fermé")
+        # les sous-programmes sont définis avant le programme principal,
+        # quel que soit leur ordre dans le fichier .algo
+        lines = [RUNTIME] + self.defs + [""] + self.out
         return "\n".join(self._unshelve_strings(l) if "\x00" in l else l
-                         for l in self.out) + "\n"
+                         for l in lines) + "\n"
 
     def _cut(self, line: str, prefix: str, suffix: str) -> str:
         s = line.strip()
@@ -383,31 +551,54 @@ class Transpiler:
 
     def _statement(self, line: str, num: int):
         norm = strip_accents(line).lower().strip()
-        # lire(a, b, ...)
-        m = re.match(r"lire\s*\((.+)\)\s*$", norm)
+        # retourner expr (dans une fonction)
+        m = re.match(r"(retourner|retourne|renvoyer)\s+(.+)$", norm)
+        if m:
+            val = re.sub(r"(?i)^(retourner|retourne|renvoyer)\s+", "", line.strip())
+            self.emit(f"return {self.expr(val, cond=False)}")
+            return
+        # lire(a, b, ...) / saisir(...)
+        m = re.match(r"(?:lire|saisir)\s*\((.+)\)\s*$", norm)
         if m:
             readers = {"entier": "_lire_entier", "reel": "_lire_reel",
-                       "chaine": "_lire_chaine", "caractere": "_lire_chaine",
+                       "chaine": "_lire_chaine", "caractere": "_lire_caractere",
                        "booleen": "_lire_booleen"}
-            inner = re.match(r"(?i)lire\s*\((.+)\)\s*$", line.strip()).group(1)
-            for v in inner.split(","):
+            inner = re.match(r"(?i)(?:lire|saisir)\s*\((.+)\)\s*$",
+                             line.strip()).group(1)
+            for v in self._split_args(inner):
                 # type déclaré dans le TDO → lecture typée (t[i] → type de t)
                 base = strip_accents(v).lower().strip().split("[")[0].strip()
                 fn = readers.get(self.types.get(base), "_lire")
                 self.emit(f"{self.expr(v, cond=False)} = {fn}()")
             return
-        # écrire(...) / écrire_nl(...)
-        m = re.match(r"(ecrire_nl|ecrire)\s*\((.*)\)\s*$", norm)
+        # écrire(...) / écrire_nl(...) / afficher(...)
+        m = re.match(r"(ecrire_nl|ecrire|afficher)\s*\((.*)\)\s*$", norm)
         if m:
             fn = "_ecrire_nl" if m.group(1) == "ecrire_nl" else "_ecrire"
             inner = re.match(r"(?i)[\wÀ-ſ_]+\s*\((.*)\)\s*$", line.strip()).group(1)
             self.emit(f"{fn}({self.expr(inner, cond=False)})")
             return
-        # affectation x ← expr  (ou instruction quelconque)
+        # affectation x ← expr
         if "←" in line or "<-" in line:
             lhs, rhs = re.split(r"←|<-", line, maxsplit=1)
             self.emit(f"{self.expr(lhs, cond=False)} = {self.expr(rhs, cond=False)}")
             return
+        # appel de procédure : les arguments @ sont réaffectés au retour
+        m = re.match(r"([\wÀ-ſ]+)\s*\((.*)\)\s*$", line.strip())
+        if m:
+            info = self.procs.get(strip_accents(m.group(1)).lower())
+            if info and info["kind"] == "procedure" and any(info["refs"]):
+                args = self._split_args(m.group(2))
+                if len(args) != len(info["refs"]):
+                    raise TranspileError(
+                        f"ligne {num}: {m.group(1)} attend {len(info['refs'])} "
+                        f"paramètre(s), {len(args)} donné(s)")
+                lhs = [self.expr(a, cond=False)
+                       for a, r in zip(args, info["refs"]) if r]
+                call_args = ", ".join(self.expr(a, cond=False) for a in args)
+                name = strip_accents(m.group(1)).lower()
+                self.emit(f"{', '.join(lhs)} = {name}({call_args})")
+                return
         self.emit(self.expr(line, cond=False))
 
 
@@ -429,7 +620,7 @@ def main():
         out_file = args[args.index("--out") + 1]
 
     try:
-        with open(path, encoding="utf-8") as f:
+        with open(path, encoding="utf-8-sig") as f:
             source = f.read()
     except FileNotFoundError:
         print(f"Erreur : fichier introuvable : {path}")

--- a/tools/exemple.algo
+++ b/tools/exemple.algo
@@ -1,0 +1,42 @@
+algorithme exemple
+// Exemple : moyenne d'un tableau + test de parité + factorielle
+début
+    n : entier
+    t : tableau de 10 réel
+    s, f : réel
+
+    écrire("Combien de notes ? ")
+    lire(n)
+
+    /* saisie contrôlée : n doit être entre 1 et 10 */
+    tant que (n < 1) ou (n > 10) faire
+        écrire("Erreur, refaire : ")
+        lire(n)
+    fin_tant_que
+
+    s ← 0
+    pour i de 1 à n faire
+        écrire("Note n°", i, " : ")
+        lire(t[i])
+        s ← s + t[i]
+    fin_pour
+
+    écrire("Moyenne = ", arrondi(s / n, 2))
+
+    si s mod 2 = 0 alors
+        écrire("La somme est paire")
+    sinon
+        écrire("La somme est impaire")
+    fin_si
+
+    // factorielle de n avec répéter
+    f ← 1
+    i ← 0
+    répéter
+        i ← i + 1
+        f ← f * i
+    jusqu'à i ≥ n
+    écrire(n, "! = ", f)
+
+    écrire("racine_carrée(", n, ") = ", arrondi(racine_carrée(n), 3))
+fin

--- a/tools/exemple2.algo
+++ b/tools/exemple2.algo
@@ -1,0 +1,20 @@
+Algorithme classique
+Debut
+    Ecrire("Donner un entier : ")
+    Lire(x)
+    Si x > 10 Alors
+        Ecrire("Grand")
+    Sinon Si x = 10 Alors
+        Ecrire("Pile dix")
+    Sinon
+        Ecrire("Petit")
+    FinSi
+    Pour i De 1 A 3 Faire
+        Ecrire("i = ", i)
+    FinPour
+    Selon x
+        1, 2 : Ecrire("un ou deux")
+        10 : Ecrire("dix")
+        Autres : Ecrire("autre valeur")
+    Fin_Selon
+Fin

--- a/tools/exemple3.algo
+++ b/tools/exemple3.algo
@@ -1,0 +1,50 @@
+algorithme Premier_Sur
+début
+    lire(n)
+    si premier(n) alors
+        écrire("Le nombre est premier")
+    sinon
+        écrire("Le nombre n'est pas premier")
+    fin_si
+    a ← 3
+    b ← 7
+    permut(@a, @b)
+    écrire("après permut : a = ", a, ", b = ", b)
+fin
+
+┌────────────────────────────────────┬──────────────────────────┐
+│               Objet                │      Nature / Type       │
+├────────────────────────────────────┼──────────────────────────┤
+│ n                                  │ entier                   │
+├────────────────────────────────────┼──────────────────────────┤
+│ a, b                               │ entier                   │
+├────────────────────────────────────┼──────────────────────────┤
+│ premier                            │ fonction                 │
+├────────────────────────────────────┼──────────────────────────┤
+│ permut                             │ procédure                │
+└────────────────────────────────────┴──────────────────────────┘
+
+fonction premier(n : entier) : booléen
+début
+    si n < 2 alors
+        retourner faux
+    fin_si
+    pour i de 2 à n - 1 faire
+        si n mod i = 0 alors
+            retourner faux
+        fin_si
+    fin_pour
+    retourner vrai
+fin
+
+procédure permut(@x : entier ; @y : entier)
+début
+    tmp ← x
+    x ← y
+    y ← tmp
+fin
+┌────────────────────────────────────┬──────────────────────────┐
+│               Objet                │      Nature / Type       │
+├────────────────────────────────────┼──────────────────────────┤
+│ tmp                                │ entier                   │
+└────────────────────────────────────┴──────────────────────────┘


### PR DESCRIPTION
Bonjour, et merci pour cette extension très utile !

Cette PR rend les fichiers `.algo` **exécutables** :

**1. `tools/algotn.py`** — un transpileur en pur Python (3.10+, aucune dépendance) qui traduit le pseudocode de l''extension en Python puis l''exécute :
- `écrire`/`lire` (alias `afficher`/`saisir`) avec **lecture typée selon les tableaux de déclaration** (TDO/TDOG/TDOL dessinés, lus où qu''ils soient dans le fichier ; type inconnu ⇒ erreur claire) ;
- `si/sinon si/sinon`, `pour … de … à … [pas]` (borne finale atteinte), `tant que`, `répéter … jusqu''à`, `selon`, tableaux indexés de 1 à n ;
- **fonctions et procédures** définies par l''utilisateur, `retourner`, passage par variable `@x` émulé (la variable est bien modifiée après l''appel), paramètres `n : entier` ou `entier n` ;
- opérateurs `= ≠ ≤ ≥ ∈ et ou non ouex div mod`, fonctions prédéfinies (`racine_carrée`, `long`, `pos`, `sous_chaîne`… — chaînes indexées à partir de 1) ;
- messages d''erreur pédagogiques en français (`fin_si` mal placé, type non défini, mot-clé mal orthographié…).

**2. `extension.js`** — une commande **▶ Exécuter l''algorithme** (bouton dans l''éditeur, `Ctrl+F5`, menu contextuel) qui lance le transpileur dans le terminal intégré. Si Python est introuvable, un message clair propose de le télécharger ou de configurer `algo.pythonPath`.

Trois exemples testés dans `tools/`, et une section « Exécution des algorithmes » ajoutée au README.

Le code est sous licence MIT (compatible GPLv3), également maintenu sur https://github.com/MajdLHB/algo-tn-compiler. Une seconde PR (outillage des tableaux de déclaration) suivra séparément — je peux adapter le découpage si vous préférez.

🤖 Generated with [Claude Code](https://claude.com/claude-code)